### PR TITLE
Add badges to show compatibility with reMarkable 1 and 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![rm1](https://img.shields.io/badge/rM1-supported-green)](https://remarkable.com/store/remarkable)
+[![rm2](https://img.shields.io/badge/rM2-unsupported-red)](https://remarkable.com/store/remarkable-2)
+
 # srvfb - Stream framebuffer content over HTTP
 
 This repository contains a small webserver that can serve the contents of a


### PR DESCRIPTION
I just tested srvfb with the reMarkable 2: The webserver logs: `32 bits per pixel unsupported` and the browser screen is black (tested with Firefox and Chrome).

The project seems to be incompatible with the rM2. It would be nice to note this somewhere in the README. I personally like the idea to use badges for that (see the [Oxide launcher](https://github.com/Eeems/oxide)), but I am open to other suggestions.